### PR TITLE
Allow nested fields

### DIFF
--- a/esdedupe/esdedupe.py
+++ b/esdedupe/esdedupe.py
@@ -9,6 +9,7 @@ import ujson
 import requests
 import sys
 
+from benedict import benedict
 from elasticsearch import Elasticsearch, helpers
 from elasticsearch.helpers import parallel_bulk
 from elasticsearch.helpers import streaming_bulk
@@ -28,15 +29,16 @@ class Esdedupe:
     # Process documents returned by the current search/scroll
     def build_index(self, docs_hash, unique_fields, hit):
         hashval = None
-        _id = hit["_id"]
+        hit_benedict = benedict(hit)
+        _id = hit_benedict["_id"]
         # there's no need to hash, if we have just single unique key
         if len(unique_fields) > 1:
             combined_key = ""
             for field in unique_fields:
-                combined_key += str(hit['_source'][field])
+                combined_key += str(hit_benedict['_source'][field])
             hashval = hashlib.md5(combined_key.encode('utf-8')).digest()
         else:
-            hashval = str(hit['_source'][unique_fields[0]])
+            hashval = str(hit_benedict['_source'][unique_fields[0]])
 
         docs_hash.setdefault(hashval, []).append(_id)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ tqdm
 psutil
 elasticsearch
 requests
+python-benedict


### PR DESCRIPTION
Currently es-dedupe - unintentionally - is able to receive nested fields as a timestamp. E.g. (`--timestamp myfield.isotimestamp`). However, attempting to use a nested field as a UID will result in `KeyError` in Python.

Using `python-benedict` will allow users to provide nested fields (e.g. `location.postal`) as a valid field, as python-benedict can use dot notation to reference a nested key.